### PR TITLE
Added polyfill for intersection observer

### DIFF
--- a/lib/element-in-viewport.js
+++ b/lib/element-in-viewport.js
@@ -1,3 +1,5 @@
+import IntersectionObserver from 'intersection-observer';
+
 /**
  * @param targetElement - The element to watch for entry into the viewport
  * @param threshold - The threshold at which to trigger the Intersection event. Must be between 0 and 1. 0 indicates first pixel in viewport. 1 indicates every pixel of element in viewport.
@@ -10,6 +12,13 @@ export default (targetElement, threshold = 0) => new Promise((resolve, reject) =
 
     if (!isThresholdValid(threshold)) {
         throw new Error('Threshold must be between 0 and 1 inclusive.');
+    }
+
+    // iOS versions previous to 12.2 don't support IntersectionObserver - add polyfill if required
+    if (!window.IntersectionObserver) {
+
+        window.IntersectionObserver = IntersectionObserver;
+
     }
 
     const options = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3108,6 +3108,11 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
+    "intersection-observer": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.7.0.tgz",
+      "integrity": "sha512-Id0Fij0HsB/vKWGeBe9PxeY45ttRiBmhFyyt/geBdDHBYNctMRTE3dC1U3ujzz3lap+hVXlEcVaB56kZP/eEUg=="
+    },
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "url": "https://github.com/smrubin/element-in-viewport/issues"
   },
   "homepage": "https://github.com/smrubin/element-in-viewport#readme",
-  "dependencies": {},
+  "dependencies": {
+    "intersection-observer": "^0.7.0"
+  },
   "devDependencies": {
     "@babel/preset-env": "^7.4.5",
     "babel-jest": "^24.8.0",


### PR DESCRIPTION
We use your package for something on our site and get a bunch of errors that IntersectionObserver is not available on iOS Safari. This is the fix we implemented and I thought you might like to have it too.

Cheers