### PR TITLE
regress ES6 syntax to be IE11 friendly

### DIFF
--- a/lib/element-in-viewport.js
+++ b/lib/element-in-viewport.js
@@ -3,39 +3,42 @@
  * @param threshold - The threshold at which to trigger the Intersection event. Must be between 0 and 1. 0 indicates first pixel in viewport. 1 indicates every pixel of element in viewport.
  * @returns {Promise<IntersectionObserverEntry>}
  */
-export default (targetElement, threshold = 0) => new Promise((resolve, reject) => {
-    if (!targetElement) {
-        throw new Error('Must specify a target element.');
-    }
-
-    if (!isThresholdValid(threshold)) {
-        throw new Error('Threshold must be between 0 and 1 inclusive.');
-    }
-
-    const options = {
-        root: null, // Document viewport
-        rootMargin: '0px',
-        threshold, // Visible amount of item shown in relation to root. 1.0 dictates that every pixel of element is visible.
-    };
-
-    const observer = new IntersectionObserver((entries, observer) => {
-        /**
-        * When the IntersectionObserver is instantiated the callback is ran once
-        * as a detection for whether the element is in view or not
-        * and if its intersection ratio exceeds the given threshold.
-        */
-        if (!entries[0].isIntersecting || entries[0].intersectionRatio < threshold) {
-            return;
+export default function(targetElement, threshold) {
+    var threshold = threshold || 0;
+    return new Promise(function(resolve, reject) {
+        if (!targetElement) {
+            throw new Error('Must specify a target element.');
         }
 
-        observer.disconnect();
+        if (!isThresholdValid(threshold)) {
+            throw new Error('Threshold must be between 0 and 1 inclusive.');
+        }
 
-        return resolve(entries[0]);
+        var options = {
+            root: null, // Document viewport
+            rootMargin: '0px',
+            threshold: threshold, // Visible amount of item shown in relation to root. 1.0 dictates that every pixel of element is visible.
+        };
 
-    }, options);
+        var observer = new IntersectionObserver(function(entries, observer) {
+            /**
+             * When the IntersectionObserver is instantiated the callback is ran once
+             * as a detection for whether the element is in view or not
+             * and if its intersection ratio exceeds the given threshold.
+             */
+            if (!entries[0].isIntersecting || entries[0].intersectionRatio < threshold) {
+                return;
+            }
 
-    observer.observe(targetElement);
+            observer.disconnect();
 
-});
+            return resolve(entries[0]);
 
-const isThresholdValid = threshold => (Number(threshold) === threshold && threshold >= 0 && threshold <= 1);
+        }, options);
+
+        observer.observe(targetElement);
+
+    });
+}
+
+function isThresholdValid(threshold) { return (Number(threshold) === threshold && threshold >= 0 && threshold <= 1); }


### PR DESCRIPTION
Since it's common for modules to be excluded from transpilation, making this compatible with IE11 will help simplify project builds. Here's a list of the ES6 syntax features I removed:

- Default function parameters
- Arrow functions
- Object property shorthand
- `const` variable declaration